### PR TITLE
Add rolling function as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,24 @@ set to `false`, the cookie will not be set on a response with an uninitialized
 session. This option only modifies the behavior when an existing session was
 loaded for the request.
 
+**Note** If this is set to true, option `rollingFunction` is ignored and every request will roll the session.
+
+##### rollingFunction
+
+Similar to [`rolling`](#rolling) option, but can conditionally roll the session. Only if the provided function returns true, the response will contain the cookie with the reset expiration to the original [`maxAge`](#cookiemaxage).
+
+```js
+/**
+ * @param {Object} req - Request object from the middleware.
+ * @returns {Boolean} - Whether the session will be rolled or not.
+ * Use req.session to access the session object.
+ */
+...
+rollingFunction: function([req]): Boolean {...}
+```
+
+**Note** In order for this function to be called, [`rolling`](#rolling) must be `false`.
+
 ##### saveUninitialized
 
 Forces a session that is "uninitialized" to be saved to the store. A session is

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ var defer = typeof setImmediate === 'function'
  * @param {Boolean} [options.proxy]
  * @param {Boolean} [options.resave] Resave unmodified sessions back to the store
  * @param {Boolean} [options.rolling] Enable/disable rolling session expiration
+ * @param {Function} [options.rollingFunction] Function for enabling/disabling rolling session expiration
  * @param {Boolean} [options.saveUninitialized] Save uninitialized sessions to the store
  * @param {String|Array} [options.secret] Secret for signing session ID
  * @param {Object} [options.store=MemoryStore] Session store
@@ -107,6 +108,9 @@ function session(options) {
 
   // get the rolling session option
   var rollingSessions = Boolean(opts.rolling)
+
+  // get the rolling function option
+  var rollingFunction = opts.rollingFunction;
 
   // get the save uninitialized session option
   var saveUninitializedSession = opts.saveUninitialized
@@ -454,6 +458,14 @@ function session(options) {
       // cannot set cookie without a session ID
       if (typeof req.sessionID !== 'string') {
         return false;
+      }
+
+      if (
+        !rollingSessions &&
+        cookieId === req.sessionID &&
+        typeof rollingFunction === "function"
+      ) {
+        return rollingFunction(req);
       }
 
       return cookieId !== req.sessionID

--- a/test/session.js
+++ b/test/session.js
@@ -1015,6 +1015,33 @@ describe('session()', function(){
       });
     });
 
+    it('should force cookie if rolling function returns true and rolling option is set', function(done){
+      var server = createServer(
+        {
+          rollingFunction: function() {
+            return true;
+          },
+          rolling: true
+        },
+        function(req, res) {
+          req.session.user = "bob";
+          res.end();
+        }
+      );
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function(err, res){
+        if (err) return done(err);
+        request(server)
+        .get('/')
+        .set('Cookie', cookie(res))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done)
+      });
+    });
+
     it('should force cookie if rolling function returns true', function(done){
       var server = createServer(
         {

--- a/test/session.js
+++ b/test/session.js
@@ -962,6 +962,85 @@ describe('session()', function(){
       });
     });
 
+    it('should not force cookie if rolling function returns false', function(done){
+      var server = createServer(
+        {
+          rollingFunction: function() {
+            return false;
+          }
+        },
+        function(req, res) {
+          req.session.user = "bob";
+          res.end();
+        }
+      );
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function(err, res){
+        if (err) return done(err);
+        request(server)
+        .get('/')
+        .set('Cookie', cookie(res))
+        .expect(shouldNotHaveHeader('Set-Cookie'))
+        .expect(200, done)
+      });
+    });
+
+    it('should force cookie if rolling function returns false and rolling option is set', function(done){
+      var server = createServer(
+        {
+          rollingFunction: function() {
+            return false;
+          },
+          rolling: true
+        },
+        function(req, res) {
+          req.session.user = "bob";
+          res.end();
+        }
+      );
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function(err, res){
+        if (err) return done(err);
+        request(server)
+        .get('/')
+        .set('Cookie', cookie(res))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done)
+      });
+    });
+
+    it('should force cookie if rolling function returns true', function(done){
+      var server = createServer(
+        {
+          rollingFunction: function() {
+            return true;
+          }
+        },
+        function(req, res) {
+          req.session.user = "bob";
+          res.end();
+        }
+      );
+
+      request(server)
+      .get('/')
+      .expect(shouldSetCookie('connect.sid'))
+      .expect(200, function(err, res){
+        if (err) return done(err);
+        request(server)
+        .get('/')
+        .set('Cookie', cookie(res))
+        .expect(shouldSetCookie('connect.sid'))
+        .expect(200, done)
+      });
+    });
+
     it('should not force cookie on uninitialized session if saveUninitialized option is set to false', function(done){
       var store = new session.MemoryStore()
       var server = createServer({ store: store, rolling: true, saveUninitialized: false })


### PR DESCRIPTION
A new option `rollingFunction` was added. This will determine if the cookie will be set on a request, similar to the `rolling` option. 

Session are rolled by default only on the store, without their `.cookie` being altered. On each request, a touch is made to the store, meaning that the object's expire is reseted and will live longer than the user's session, leading to different expire dates between the store and the user session. This behaviour has already been [reported](https://github.com/expressjs/session/issues/624).

Using `rolling`  will set-cookie with the same session ID, but with reseted maxAge, this is the desired behaviour, as the session is extended and the expires are equal between the client and the server.

Somehow, we need to be able to conditionally or [manually](https://github.com/expressjs/session/issues/688) _roll_ sessions. This is where _rollingFunction_ comes in handy.

